### PR TITLE
Misc Improvements

### DIFF
--- a/app/components/meilisearch/ChangeInstanceModal.vue
+++ b/app/components/meilisearch/ChangeInstanceModal.vue
@@ -65,7 +65,7 @@ async function handleChangeInstance() {
             <div class="flex gap-4">
                 <Button
                     label="Cancel"
-                    plain
+                    severity="secondary"
                     text
                     @click="modalOpen = false"
                 />

--- a/app/components/meilisearch/CreateIndexModal.vue
+++ b/app/components/meilisearch/CreateIndexModal.vue
@@ -2,17 +2,20 @@
 import { useIndexes } from '@/composables/meilisearch/useIndexes'
 import type { IndexOptions } from 'meilisearch'
 
-const drawerOpen = defineModel<boolean>({ default: false })
+const visible = defineModel<boolean>('visible', { default: false })
 
-const emit = defineEmits(['hide', 'index-created'])
+const emit = defineEmits<{
+    'index-created': []
+}>()
 
 const { isSendingTask, createIndex } = useIndexes()
 
 const uid = ref<string>('')
 const primaryKey = ref<string>()
+
 function submitNewIndex() {
     createIndex(uid.value, { primaryKey: primaryKey.value } as IndexOptions).then(() => {
-        drawerOpen.value = false
+        visible.value = false
         emit('index-created')
     }).catch(() => {
         //
@@ -24,10 +27,16 @@ function reset() {
     primaryKey.value = undefined
 }
 
-function handleHideDrawer() {
+function handleCancel() {
+    visible.value = false
     reset()
-    emit('hide')
 }
+
+watch(visible, (isVisible) => {
+    if (isVisible) {
+        reset()
+    }
+})
 
 watch(primaryKey, (newVal) => {
     if (newVal === '') {
@@ -37,23 +46,24 @@ watch(primaryKey, (newVal) => {
 </script>
 
 <template>
-    <Drawer
-        v-model:visible="drawerOpen"
+    <Dialog
+        v-model:visible="visible"
+        class="w-full sm:w-[30rem]"
+        position="center"
         header="New Index"
-        class="w-full sm:w-[40rem]"
-        position="right"
-        @hide="handleHideDrawer"
+        :draggable="false"
+        dismissable-mask
+        modal
     >
         <form
             id="create-index-form"
-            class="space-y-6 sm:space-y-8"
+            class="flex flex-col gap-6"
             @submit.prevent="submitNewIndex"
         >
             <div class="flex flex-col gap-2">
                 <label for="new-index-uid">UID</label>
                 <InputText
                     id="new-index-uid"
-                    ref="uid-input"
                     v-model="uid"
                     placeholder="uid of the requested index"
                     type="text"
@@ -73,12 +83,20 @@ watch(primaryKey, (newVal) => {
             </div>
         </form>
         <template #footer>
-            <Button
-                type="submit"
-                form="create-index-form"
-                label="Submit"
-                :loading="isSendingTask"
-            />
+            <div class="flex gap-4">
+                <Button
+                    label="Cancel"
+                    severity="secondary"
+                    text
+                    @click="handleCancel"
+                />
+                <Button
+                    type="submit"
+                    form="create-index-form"
+                    label="Submit"
+                    :loading="isSendingTask"
+                />
+            </div>
         </template>
-    </Drawer>
+    </Dialog>
 </template>

--- a/app/components/meilisearch/CreateKeyDrawer.vue
+++ b/app/components/meilisearch/CreateKeyDrawer.vue
@@ -5,9 +5,10 @@ import type { KeyCreation } from 'meilisearch'
 import { useToast } from 'primevue'
 import { CircleQuestionMark, Info } from '@lucide/vue'
 
-const drawerOpen = defineModel<boolean>({ default: false })
+const visible = defineModel<boolean>('visible', { default: false })
 
-const emit = defineEmits(['hide', 'key-created'])
+const emit = defineEmits(['key-created'])
+
 
 const toast = useToast()
 const { indexes, isFetching: isFetchingIndexes, fetchAllIndexes } = useIndexes()
@@ -63,7 +64,7 @@ function submitNewKey() {
             detail: `The API key: "${newKey.value.name}" was successfully created`,
             life: 3000,
         })
-        drawerOpen.value = false
+        visible.value = false
         emit('key-created')
     }).catch(() => {
         // TODO
@@ -78,10 +79,12 @@ function reset() {
     allActions.value = false
 }
 
-function handleHideDrawer() {
-    reset()
-    emit('hide')
-}
+watch(visible, (isVisible) => {
+    if (isVisible) {
+        fetchAllIndexes()
+        reset()
+    }
+})
 
 watch(newKey, (newVal) => {
     if (newVal.uid === '') {
@@ -104,12 +107,10 @@ watch(allActions, (newVal) => {
 
 <template>
     <Drawer
-        v-model:visible="drawerOpen"
+        v-model:visible="visible"
         header="New API Key"
         class="w-full sm:w-[40rem]"
         position="right"
-        @show="fetchAllIndexes"
-        @hide="handleHideDrawer"
     >
         <form
             id="create-key-form"

--- a/app/components/meilisearch/EditDocumentDrawer.vue
+++ b/app/components/meilisearch/EditDocumentDrawer.vue
@@ -13,9 +13,10 @@ const props = withDefaults(defineProps<{
     document: null,
 })
 
-const emit = defineEmits(['hide', 'document-updated'])
+const emit = defineEmits(['document-updated'])
 
-const drawerOpen = defineModel<boolean>({ default: false })
+
+const visible = defineModel<boolean>('visible', { default: false })
 
 const { addOrUpdateDocuments, isSendingTask, error } = useDocuments()
 
@@ -23,7 +24,7 @@ const updatedDocument = ref<RecordAny>(props.document ?? {})
 function handleSaveDocument() {
     addOrUpdateDocuments('update', props.indexUid, [updatedDocument.value], props.primaryKey)
         .then(() => {
-            drawerOpen.value = false
+            visible.value = false
             emit('document-updated')
         })
 }
@@ -45,11 +46,10 @@ watch(() => props.document, (newVal: RecordAny | null) => {
 
 <template>
     <Drawer
-        v-model:visible="drawerOpen"
+        v-model:visible="visible"
         header="Edit Document"
         class="w-full sm:w-[60rem]"
         position="right"
-        @hide="$emit('hide')"
     >
         <div class="flex flex-col gap-4 mt-1">
             <div v-if="hasErrors">

--- a/app/components/meilisearch/EditKeyDrawer.vue
+++ b/app/components/meilisearch/EditKeyDrawer.vue
@@ -11,9 +11,10 @@ const props = withDefaults(defineProps<{
     apiKey: null,
 })
 
-const drawerOpen = defineModel<boolean>({ default: false })
+const visible = defineModel<boolean>('visible', { default: false })
 
-const emit = defineEmits(['hide', 'key-updated'])
+const emit = defineEmits(['key-updated'])
+
 
 const toast = useToast()
 const { indexes, isFetching: isFetchingIndexes, fetchAllIndexes } = useIndexes()
@@ -34,12 +35,18 @@ function saveNewKey() {
             detail: `The API key: "${keyToUpdate.value.name}" was successfully updated`,
             life: 3000,
         })
-        drawerOpen.value = false
+        visible.value = false
         emit('key-updated')
     }).catch(() => {
         //
     })
 }
+
+watch(visible, (isVisible) => {
+    if (isVisible) {
+        fetchAllIndexes()
+    }
+})
 
 watch(keyToUpdate, (newVal) => {
     if (newVal.name === '') {
@@ -62,12 +69,10 @@ watch(() => props.apiKey, (newVal: Key | null) => {
 
 <template>
     <Drawer
-        v-model:visible="drawerOpen"
+        v-model:visible="visible"
         header="Edit API Key"
         class="w-full sm:w-[40rem]"
         position="right"
-        @show="fetchAllIndexes"
-        @hide="$emit('hide')"
     >
         <form
             id="edit-key-form"

--- a/app/components/meilisearch/FilterDocumentsDrawer.vue
+++ b/app/components/meilisearch/FilterDocumentsDrawer.vue
@@ -12,11 +12,9 @@ const props = defineProps<{
     enableGeoFilters?: boolean,
 }>()
 
-const drawerOpen = defineModel<boolean>({ default: false })
+const visible = defineModel<boolean>('visible', { default: false })
 const filter = defineModel<Filter | null>('filter', { required: true })
 const geoSort = defineModel<string | null>('geoSort', { default: null })
-
-const emit = defineEmits(['hide', 'searched'])
 
 const { searchFacetValues } = useFacetSearch()
 
@@ -69,10 +67,6 @@ const hasGeoFilterSupport = computed(() => {
 const hasGeoSortSupport = computed(() => {
     return ((props.sortableAttributes as string[]) ?? []).includes('_geo')
 })
-
-function handleHideDrawer() {
-    emit('hide')
-}
 
 function updateFacetFilterValue(attributeName: string, value: string[]) {
     const facetFilter = facetFilters.value[attributeName]
@@ -333,11 +327,10 @@ watch(() => props.enableGeoFilters, (enabled) => {
 
 <template>
     <Drawer
-        v-model:visible="drawerOpen"
+        v-model:visible="visible"
         header="Filter Documents"
         class="w-full sm:w-[30rem]"
         position="right"
-        @hide="handleHideDrawer"
     >
         <!-- TODO: manual input search -->
         <div class="mt-1 relative flex flex-col gap-4">

--- a/app/components/meilisearch/HybridSearchModal.vue
+++ b/app/components/meilisearch/HybridSearchModal.vue
@@ -127,7 +127,7 @@ watch(() => props.embedders, () => {
             <div class="flex gap-4">
                 <Button
                     label="Cancel"
-                    plain
+                    severity="secondary"
                     text
                     @click="handleCancel"
                 />

--- a/app/components/meilisearch/ImportDocumentsDrawer.vue
+++ b/app/components/meilisearch/ImportDocumentsDrawer.vue
@@ -12,9 +12,9 @@ const props = defineProps<{
     primaryKey?: string,
 }>()
 
-const emit = defineEmits(['hide', 'documents-imported'])
+const emit = defineEmits(['documents-imported'])
 
-const drawerOpen = defineModel<boolean>({ default: false })
+const visible = defineModel<boolean>('visible', { default: false })
 
 const { addOrUpdateDocuments, addOrUpdateDocumentsFromString, isSendingTask, error } = useDocuments()
 
@@ -70,13 +70,13 @@ async function handleSaveDocument() {
         // TODO: handle JSON errors (reference settings)
         addOrUpdateDocuments(importMode.value, props.indexUid, newDocuments.value, props.primaryKey)
             .then(() => {
-                drawerOpen.value = false
+                visible.value = false
                 emit('documents-imported')
             })
     } else {
         addOrUpdateDocumentsFromString(importMode.value, props.indexUid, newDocumentsAsString.value, uploadContentType.value)
             .then(() => {
-                drawerOpen.value = false
+                visible.value = false
                 emit('documents-imported')
             })
     }
@@ -90,10 +90,11 @@ function reset() {
     newDocumentsAsString.value = ''
 }
 
-function handleHidden() {
-    emit('hide')
-    reset()
-}
+watch(visible, (isVisible) => {
+    if (!isVisible) {
+        reset()
+    }
+})
 
 watch(() => newDocuments.value, (newVal) => {
     if (importMethod.value === 'manual') {
@@ -107,16 +108,14 @@ watch(uploadContentType, (newVal) => {
         handleUploaderReset()
     }
 })
-
 </script>
 
 <template>
     <Drawer
-        v-model:visible="drawerOpen"
+        v-model:visible="visible"
         header="Import Documents"
         class="w-full sm:w-[60rem]"
         position="right"
-        @hide="handleHidden"
     >
         <div class="flex flex-col gap-6">
             <div class="flex flex-col gap-2">

--- a/app/components/meilisearch/KeyDetailsDrawer.vue
+++ b/app/components/meilisearch/KeyDetailsDrawer.vue
@@ -4,14 +4,16 @@ import { formatDate, maskedApiKey } from '@/utils'
 import { useClipboard } from '@vueuse/core'
 import { Check, Copy } from '@lucide/vue'
 
-const drawerOpen = defineModel<boolean>({ default: false })
+const visible = defineModel<boolean>('visible', { default: false })
 
 const props = defineProps<{
     apiKey: Key,
     copiedKeyUid: string | null,
 }>()
 
-defineEmits(['hide', 'copy-key'])
+const emit = defineEmits<{
+    'copy-key': [key: string, uid: string]
+}>()
 
 const { isSupported: canCopy } = useClipboard()
 
@@ -30,11 +32,10 @@ const keyExpired = computed(() => {
 <template>
     <Drawer
         :key="props.apiKey.uid"
-        v-model:visible="drawerOpen"
+        v-model:visible="visible"
         :header="keyName"
         class="w-full sm:w-[40rem]"
         position="right"
-        @hide="$emit('hide')"
     >
         <div class="space-y-4">
             <Fieldset legend="UID">
@@ -63,7 +64,7 @@ const keyExpired = computed(() => {
                         severity="secondary"
                         size="small"
                         text
-                        @click="$emit('copy-key', props.apiKey.key, props.apiKey.uid)"
+                        @click="emit('copy-key', props.apiKey.key, props.apiKey.uid)"
                     >
                         <Check v-if="keyCopied" />
                         <Copy v-else />

--- a/app/components/meilisearch/SearchRuleActionModal.vue
+++ b/app/components/meilisearch/SearchRuleActionModal.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { useMeilisearchStore } from '@/stores/meilisearch'
 import { useIndexes } from '@/composables/meilisearch/useIndexes'
+import { useDocuments } from '@/composables/meilisearch/useDocuments'
 import { useDebounceFn } from '@vueuse/core'
 import type { SearchRuleAction, SearchRuleSelector, SearchRulePinAction, RecordAny } from 'meilisearch'
+import ThemedJsonViewer from '@/components/ThemedJsonViewer.vue'
 
 const visible = defineModel<boolean>('visible', { default: false })
 const action = defineModel<SearchRuleAction>('action', { required: true })
@@ -13,6 +15,7 @@ const emit = defineEmits<{
 
 const meilisearchStore = useMeilisearchStore()
 const { indexes, fetchAllIndexes } = useIndexes()
+const { document: fetchedDocument, isFetching: isFetchingDocument, fetchDocument } = useDocuments()
 
 const actionTypeOptions = [
     { label: 'Pin', value: 'pin' },
@@ -39,14 +42,16 @@ function resetForm() {
         selectedIndexUid.value = ''
     }
 
-    if (a.selector?.id) {
+    if (a.selector?.id && a.selector?.indexUid) {
         selectedDocumentId.value = a.selector.id
         documentQuery.value = String(a.selector.id)
         autoCompleteModel.value = documentQuery.value
+        fetchDocument(a.selector.indexUid, a.selector.id)
     } else {
         selectedDocumentId.value = null
         documentQuery.value = ''
         autoCompleteModel.value = ''
+        fetchedDocument.value = null
     }
 
     position.value = (a.action as SearchRulePinAction)?.position ?? 0
@@ -137,6 +142,21 @@ function handleCancel() {
     visible.value = false
 }
 
+function onIndexChange() {
+    selectedDocumentId.value = null
+    documentQuery.value = ''
+    autoCompleteModel.value = ''
+    fetchedDocument.value = null
+}
+
+watch([selectedIndexUid, selectedDocumentId], ([indexUid, docId]) => {
+    if (indexUid && docId) {
+        fetchDocument(indexUid, docId)
+    } else {
+        fetchedDocument.value = null
+    }
+})
+
 watch(visible, (isVisible) => {
     if (isVisible) {
         fetchAllIndexes()
@@ -177,6 +197,7 @@ watch(visible, (isVisible) => {
                     :options="indexes.map(i => i.uid)"
                     placeholder="Select an index"
                     fluid
+                    @change="onIndexChange"
                 />
             </div>
 
@@ -204,6 +225,19 @@ watch(visible, (isVisible) => {
                         </div>
                     </template>
                 </AutoComplete>
+
+                <div
+                    v-if="isFetchingDocument"
+                    class="text-sm text-muted-color"
+                >
+                    Loading document...
+                </div>
+                <div
+                    v-else-if="fetchedDocument"
+                    class="border dynamic-border rounded-border overflow-auto max-h-50"
+                >
+                    <ThemedJsonViewer :data="fetchedDocument" />
+                </div>
             </div>
 
             <div class="flex flex-col gap-2">
@@ -222,7 +256,7 @@ watch(visible, (isVisible) => {
             <div class="flex gap-4">
                 <Button
                     label="Cancel"
-                    plain
+                    severity="secondary"
                     text
                     @click="handleCancel"
                 />

--- a/app/components/meilisearch/SearchRuleConditionModal.vue
+++ b/app/components/meilisearch/SearchRuleConditionModal.vue
@@ -190,7 +190,7 @@ watch(visible, (isVisible) => {
             <div class="flex gap-4">
                 <Button
                     label="Cancel"
-                    plain
+                    severity="secondary"
                     text
                     @click="handleCancel"
                 />

--- a/app/components/meilisearch/SearchRuleForm.vue
+++ b/app/components/meilisearch/SearchRuleForm.vue
@@ -380,6 +380,7 @@ function onActionSave() {
             <Button
                 label="Cancel"
                 severity="secondary"
+                text
                 @click="emit('cancel')"
             />
             <Button

--- a/app/components/meilisearch/TaskDetailsDrawer.vue
+++ b/app/components/meilisearch/TaskDetailsDrawer.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import type { Task } from 'meilisearch'
+import { Mode } from 'vanilla-jsoneditor'
+import ThemedJsonEditor from '../ThemedJsonEditor.vue'
+
+const props = defineProps<{
+    task: Task | null,
+}>()
+
+const visible = defineModel<boolean>('visible', { default: false })
+
+const headerTitle = computed(() => `Task ${props.task?.uid}`)
+</script>
+
+<template>
+    <Drawer
+        v-model:visible="visible"
+        :header="headerTitle"
+        class="w-full sm:w-[60rem]"
+        position="right"
+    >
+        <div>
+            <ThemedJsonEditor
+                :modelValue="task"
+                :mode="Mode.text"
+                :main-menu-bar="false"
+                :stringified="false"
+                read-only
+            />
+        </div>
+    </Drawer>
+</template>

--- a/app/composables/meilisearch/useDocuments.ts
+++ b/app/composables/meilisearch/useDocuments.ts
@@ -10,6 +10,7 @@ export function useDocuments() {
     const meilisearchStore = useMeilisearchStore()
     const { pollTaskStatus } = useTasks()
 
+    const document = ref<RecordAny | null>(null)
     const isFetching = ref(false)
     const isLoading = ref(false)
     const isSendingTask = ref(false)
@@ -18,6 +19,31 @@ export function useDocuments() {
     const error = ref<string | null>(null)
 
     const isLoadingTask = computed(() => isSendingTask.value || isPollingTask.value)
+
+    async function fetchDocument(
+        indexUid: string,
+        documentId: string | number
+    ): Promise<RecordAny | undefined> {
+        const client = meilisearchStore.getClient()
+        if (!client) {
+            error.value = 'Meilisearch client not connected'
+            return
+        }
+
+        isFetching.value = true
+        error.value = null
+
+        try {
+            const result = await client.index(indexUid).getDocument(documentId)
+            document.value = result
+            return result
+        } catch (err) {
+            document.value = null
+            error.value = (err as Error).message
+        } finally {
+            isFetching.value = false
+        }
+    }
 
     async function addOrUpdateDocuments(
         action: 'addition' | 'update',
@@ -242,12 +268,14 @@ export function useDocuments() {
     })
 
     return {
+        document,
         isFetching,
         isLoading,
         isSendingTask,
         isPollingTask,
         isLoadingTask,
         error,
+        fetchDocument,
         addOrUpdateDocuments,
         addOrUpdateDocumentsFromString,
         confirmDeleteAllDocuments,

--- a/app/pages/indexes/[uid]/documents.vue
+++ b/app/pages/indexes/[uid]/documents.vue
@@ -142,14 +142,13 @@ function editDocument(document: RecordAny) {
     currentDocument.value = document
     editDocumentDrawerOpen.value = true
 }
-function handleEditDrawerHidden() {
-    if (!isSendingTask.value) {
-        // delayed null reset to allow the drawer close animation to complete
+watch(editDocumentDrawerOpen, (isOpen) => {
+    if (!isOpen && !isSendingTask.value) {
         setTimeout(() => {
             currentDocument.value = null
         }, 250)
     }
-}
+})
 
 // Hybrid search
 const hybridSearchModalOpen = ref(false)
@@ -306,21 +305,20 @@ onMounted(() => {
         <Teleport to="body">
             <div class="relative">
                 <ImportDocumentsDrawer
-                    v-model="showImportDocumentsDrawerOpen"
+                    v-model:visible="showImportDocumentsDrawerOpen"
                     :index-uid="indexUid"
                     :primary-key="currentIndex?.primaryKey"
                     @documents-imported="fetchData"
                 />
                 <EditDocumentDrawer
-                    v-model="editDocumentDrawerOpen"
+                    v-model:visible="editDocumentDrawerOpen"
                     :index-uid="indexUid"
                     :primary-key="currentIndex?.primaryKey"
                     :document="currentDocument"
                     @document-updated="fetchData"
-                    @hide="handleEditDrawerHidden"
                 />
                 <FilterDocumentsDrawer
-                    v-model="showFilteringDrawerOpen"
+                    v-model:visible="showFilteringDrawerOpen"
                     v-model:filter="searchFilter"
                     v-model:geo-sort="searchGeoSort"
                     :index-uid="indexUid"

--- a/app/pages/indexes/[uid]/settings.vue
+++ b/app/pages/indexes/[uid]/settings.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useSettings } from '@/composables/meilisearch/useSettings'
-import { AlertCircle, CircleQuestionMark, Pencil, TriangleAlert, X } from '@lucide/vue'
+import { AlertCircle, CircleQuestionMark, Pencil, TriangleAlert, X, Check } from '@lucide/vue'
 import { Mode } from 'vanilla-jsoneditor'
 
 definePageMeta({
@@ -82,6 +82,7 @@ watch(() => settings.value, (newVal) => {
                         <Button
                             label="Cancel"
                             severity="secondary"
+                            text
                             @click="toggleEditMode"
                         >
                             <template #icon>
@@ -92,7 +93,11 @@ watch(() => settings.value, (newVal) => {
                             label="Save"
                             :loading="isLoadingTask"
                             @click="handleUpdateSettings"
-                        />
+                        >
+                            <template #icon>
+                                <Check />
+                            </template>
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/app/pages/indexes/index.vue
+++ b/app/pages/indexes/index.vue
@@ -3,7 +3,7 @@ import { useStats } from '@/composables/meilisearch/useStats'
 import { ArrowRight, Home, Plus } from '@lucide/vue'
 import PageTitleSection from '@/components/PageTitleSection.vue'
 import { useIndexes } from '@/composables/meilisearch/useIndexes'
-import CreateIndexDrawer from '@/components/meilisearch/CreateIndexDrawer.vue'
+import CreateIndexModal from '@/components/meilisearch/CreateIndexModal.vue'
 import NotFoundMessage from '@/components/NotFoundMessage.vue'
 import { formatNumber, formatDate } from '@/utils'
 
@@ -32,7 +32,7 @@ async function fetchData() {
 }
 await fetchData()
 
-const createIndexDrawerOpen = ref(false)
+const createIndexModalOpen = ref(false)
 
 const indexesData = computed(() => {
     return indexes.value.map((index) => {
@@ -46,12 +46,10 @@ const indexesData = computed(() => {
 
 <template>
     <div class="flex flex-col gap-4 md:gap-8">
-        <Teleport to="body">
-            <CreateIndexDrawer
-                v-model="createIndexDrawerOpen"
-                @index-created="fetchData"
-            />
-        </Teleport>
+        <CreateIndexModal
+            v-model:visible="createIndexModalOpen"
+            @index-created="fetchData"
+        />
 
         <PageTitleSection>
             <template #title>
@@ -65,7 +63,7 @@ const indexesData = computed(() => {
                     />
                     <Button
                         label="New Index"
-                        @click="createIndexDrawerOpen = true"
+                        @click="createIndexModalOpen = true"
                     >
                         <template #icon>
                             <Plus />

--- a/app/pages/keys.vue
+++ b/app/pages/keys.vue
@@ -84,12 +84,20 @@ function toggleKeyContextMenu(event: Event, key: Key) {
     }
 }
 
-function resetCurrentKey() {
-    // delayed null reset to allow the drawer close animation to complete
-    setTimeout(() => {
-        currentKey.value = null
-    }, 250)
-}
+watch(keyDetailsDrawerOpen, (isOpen) => {
+    if (!isOpen) {
+        setTimeout(() => {
+            currentKey.value = null
+        }, 250)
+    }
+})
+watch(editKeyDrawerOpen, (isOpen) => {
+    if (!isOpen) {
+        setTimeout(() => {
+            currentKey.value = null
+        }, 250)
+    }
+})
 
 const lastCopiedKeyUid = ref()
 async function copyApiKey(key: string, uid: string) {
@@ -109,20 +117,18 @@ const keyCopiedUid = computed(() => (copied.value && lastCopiedKeyUid.value) ? l
         <Teleport to="body">
             <KeyDetailsDrawer
                 v-if="currentKey"
-                v-model="keyDetailsDrawerOpen"
+                v-model:visible="keyDetailsDrawerOpen"
                 :api-key="currentKey"
                 :copied-key-uid="keyCopiedUid"
-                @hide="resetCurrentKey"
                 @copy-key="copyApiKey"
             />
             <CreateKeyDrawer
-                v-model="newKeyDrawerOpen"
+                v-model:visible="newKeyDrawerOpen"
                 @key-created="fetchKeysPaginated"
             />
             <EditKeyDrawer
-                v-model="editKeyDrawerOpen"
+                v-model:visible="editKeyDrawerOpen"
                 :api-key="currentKey"
-                @hide="resetCurrentKey"
                 @key-updated="fetchKeysPaginated"
             />
         </Teleport>

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -4,8 +4,8 @@ import { useTasks } from '@/composables/meilisearch/useTasks'
 import { useIndexes } from '@/composables/meilisearch/useIndexes'
 import { Home, Info } from '@lucide/vue'
 import type { Task, TasksOrBatchesQuery } from 'meilisearch'
-import { Mode } from 'vanilla-jsoneditor'
 import { formatDate, getStatusSeverity } from '@/utils'
+import TaskDetailsDrawer from '@/components/meilisearch/TaskDetailsDrawer.vue'
 
 definePageMeta({
     layout: 'app',
@@ -77,13 +77,19 @@ await refreshTasksList(false)
 
 const indexUids = computed(() => indexes.value.map((index) => index.uid))
 
-const showTaskDrawerOpen = ref(false)
 const currentTask = ref<Task | null>(null)
-const taskHeaderTitle = computed(() => `Task ${currentTask.value?.uid}`)
+const taskDetailsDrawerOpen = ref(false)
 function showTask(task: Task) {
     currentTask.value = task
-    showTaskDrawerOpen.value = true
+    taskDetailsDrawerOpen.value = true
 }
+watch(taskDetailsDrawerOpen, (isOpen) => {
+    if (!isOpen) {
+        setTimeout(() => {
+            currentTask.value = null
+        }, 250)
+    }
+})
 
 watch(currentTasksQuery, async () => {
     await refreshTasksList()
@@ -108,25 +114,10 @@ onMounted(() => {
 
 <template>
     <div class="flex flex-col gap-4 md:gap-8">
-        <Teleport to="body">
-            <Drawer
-                v-model:visible="showTaskDrawerOpen"
-                :header="taskHeaderTitle"
-                class="w-full sm:w-[60rem]"
-                position="right"
-                @hide="currentTask = null"
-            >
-                <div>
-                    <ThemedJsonEditor
-                        v-model="currentTask"
-                        :mode="Mode.text"
-                        :main-menu-bar="false"
-                        :stringified="false"
-                        read-only
-                    />
-                </div>
-            </Drawer>
-        </Teleport>
+        <TaskDetailsDrawer
+            v-model:visible="taskDetailsDrawerOpen"
+            :task="currentTask"
+        />
 
         <PageTitleSection>
             <template #title>


### PR DESCRIPTION
- **feat(SearchRuleActionModal): display fetched document preview below autocomplete**
  - Added `fetchDocument(indexUid, documentId)` to `useDocuments.ts` composable, following existing patterns
  - Modal now auto-fetches the selected document by its primary key when an ID is present (editing or real-time selection)
  - Displays the fetched document using `<ThemedJsonViewer>` below the AutoComplete input so users can see what object is actually selected
  - Document preview clears automatically when the index is changed
- **refactor(CreateIndexDrawer → CreateIndexModal): convert drawer to modal**
  - Replaced `<Drawer>` with `<Dialog>` using the standard modal pattern (`position="center"`, `dismissableMask`, `modal`)
  - Renamed internal ref from `drawerOpen` to `visible` for consistency
  - Added `handleCancel()` and `watch(visible, …)` to reset form on open
  - Updated `pages/indexes/index.vue` to use `CreateIndexModal` with `v-model` and removed `<Teleport>` wrapper
- **refactor(all Drawer components): adopt `visible` named defineModel**
  - Updated all 6 reusable Drawer components (`CreateKeyDrawer`, `EditKeyDrawer`, `KeyDetailsDrawer`, `EditDocumentDrawer`, `FilterDocumentsDrawer`, `ImportDocumentsDrawer`) to use `defineModel<boolean>('visible', { default: false })`
  - Extracted inline task details drawer from `pages/tasks.vue` into new reusable `TaskDetailsDrawer.vue`
  - Parent pages (`keys.vue`, `indexes/[uid]/documents.vue`, `tasks.vue`) updated to bind via `v-model:visible`
- **cleanup(drawers): remove `hide` emits and centralize cleanup in parents**
  - Removed `'hide'` emit declarations from all 7 drawer components
  - Removed `handleHideDrawer()`, `handleCancel()`, and `watch(visible)` emit logic from drawers
  - Removed unused `'searched'` emit from `FilterDocumentsDrawer`
  - Moved delayed null-reset cleanup logic into parent page `watch` statements on the visibility refs
  - Parent watches handle resetting `currentKey`, `currentDocument`, and `currentTask` after drawer close animations complete
  
(This summary was generated with Agentic AI)